### PR TITLE
add browser support (via browserify): use built-in browser HTML parser to strip HTML from text

### DIFF
--- a/lib/sanitize-html-browser.js
+++ b/lib/sanitize-html-browser.js
@@ -1,0 +1,13 @@
+module.exports = function sanitizeHtml(text, opts) {
+
+    if (typeof text == 'string' || text instanceof String) {  // Strip HTML from Text using browser HTML parser
+      var $div = document.createElement("DIV");
+      $div.innerHTML = text;
+      text =  ($div.textContent || '').trim();
+    } else if (typeof text === 'object' && text.textContent) { //DOM Object
+      text = (text.textContent || '').trim();
+    }
+
+    return text;
+
+};

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -1,7 +1,6 @@
 /*jshint node:true, laxcomma:true */
 "use strict";
 
-var sugar = require('sugar');
 var sanitizeHtml = require('sanitize-html');
 
 var String = require('./String');
@@ -29,11 +28,11 @@ exports.sentences = function sentences(text, newline_boundary) {
     }
 
     // Split the text into words
-    var words = text.words();
+    var words = text.match(/\S+/g); // see http://blog.tompawlak.org/split-string-into-tokens-javascript
     var sentences = [];
     var current   = [];
 
-    for (i in words) {
+    for (i=0; i<words.length; i++) {
         // Add the word to current sentence
         current.push(words[i]);
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "mocha": "1.7.x"
   },
   "dependencies": {
-    "sanitize-html": "^1.4.3",
-    "sugar": "~1.4.1"
+    "sanitize-html": "^1.4.3"
+  },
+  "browser": {
+    "sanitize-html": "./lib/sanitize-html-browser.js"
   }
 }


### PR DESCRIPTION
the ```browser``` property in package.json tells browserify to replace "sanitize-html" by "./lib/sanitize-html-browser.js". The latter file take care of stripping HTML from text in a browser environment.

I also removed the dependency to sugar.