### PR TITLE
Provide an option to turn off HTML sanitization

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ var sentences = tokenizer.sentences(textFromFile, true);
 // ]
 ```
 
+The second argument can also be a configuration object, that can support the following values:
+
+* `newline_boundary`: the same as specifying the second argument as a boolean.
+* `sanitize`: set this to `false` in order to disable automatic HTML sanitization. While automatic
+  sanitization has to remain the default for backwards compatibility purposes, unless you are
+  specifically providing `sbd` with content you know to contain HTML it is recommended to switch
+  this off as it can mangle your content.
+
 ## Future work
 
 * Convert quotes to normalized unicode ""

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -10,16 +10,25 @@ var newline_placeholder = " @~@ ";
 var newline_placeholder_t = newline_placeholder.trim();
 
 // Split the entry into sentences.
-exports.sentences = function(text, newline_boundary) {
+exports.sentences = function(text, options) {
     if (text.length === 0)
         return [];
 
-    text = sanitizeHtml(text, { "allowedTags" : [''] });
-
-    /** Preprocessing */
-    if (typeof newline_boundary === 'undefined') {
+    /** Options processing */
+    var newline_boundary;
+    var do_sanitize = true;
+    if (typeof options === 'undefined') {
         newline_boundary = false;
     }
+    else if (typeof options === 'object') {
+      newline_boundary = options.newline_boundary || false;
+      do_sanitize = typeof options.sanitize === 'undefined' ? true : options.sanitize;
+    }
+    else {
+        newline_boundary = options;
+    }
+
+    text = do_sanitize ? sanitizeHtml(text, { "allowedTags" : [''] }) : text;
 
     if (newline_boundary) {
         text = text.replace(/\n+|[-#=_+*]{4,}/g, newline_placeholder);

--- a/test/html.js
+++ b/test/html.js
@@ -16,4 +16,17 @@ describe('HTML markup', function () {
         });
     });
 
+    describe('Non-markup is not interfered with', function () {
+        var entry = "We find that a < b works. But in turn, c > x.";
+        var sentences = tokenizer.sentences(entry, { sanitize: false });
+
+        it("should get 2 sentences", function () {
+            assert.equal(sentences.length, 2);
+        });
+        it("should not be escaped", function () {
+            assert(!/&lt;/.test(sentences[0]));
+            assert(!/&gt;/.test(sentences[1]));
+        });
+    });
+
 });


### PR DESCRIPTION
The automatic HTML sanitization tripped me over. If you are not providing `sbd` with HTML, it can mangle your content (I was getting back a string with `&lt;` instead of `<`).