### PR TITLE
Fix newlines

### DIFF
--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -54,7 +54,7 @@ exports.sentences = function(text, user_options) {
     }
 
     // Split the text into words
-    var words = text.trim().match(/\S+/g); // see http://blog.tompawlak.org/split-string-into-tokens-javascript
+    var words = text.trim().match(/\S+|\n/g); // see http://blog.tompawlak.org/split-string-into-tokens-javascript
     var wordCount = 0;
     var index = 0;
     var temp  = [];

--- a/test/newline.js
+++ b/test/newline.js
@@ -1,0 +1,17 @@
+/*jshint node:true, laxcomma:true */
+/*global describe:true, it:true */
+"use strict";
+
+var assert = require('assert');
+var tokenizer = require('../lib/tokenizer');
+
+describe('Save newlines', function () {
+    describe('Basic', function () {
+        var entry = "First sentence... Another list: \n - green \n - blue \n - red";
+        var sentences = tokenizer.sentences(entry);
+
+        it('second sentence should have newlines', function () {
+            assert.equal(sentences[1], "Another list: \n - green \n - blue \n - red");
+        });
+    });
+});


### PR DESCRIPTION
Lib removes newlines, e.g. changes sentence:
```
Test:
- aaa
- bbb
```

to `Test - aaa -bbb`

This commit fixed it.