### PR TITLE
add option to preserve whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ var options = {
     "html_boundaries"    : false,
     "sanitize"           : false,
     "allowed_tags"       : false,
+    "preserve_whitespace" : false,
     "abbreviations"      : null
 };
 ```
@@ -47,6 +48,7 @@ var options = {
 * `html_boundaries`, force sentence split at specific tags (br, and closing p, div, ul, ol)
 * `sanitize`: If you don't expect nor want html in your text.
 * `allowed_tags`: To sanitize html, the library [santize-html](https://github.com/punkave/sanitize-html) is used. You can pass the allowed tags option.
+* `preserve_whitespace`: Preserve the literal whitespace between words and sentences (otherwise, internal spaces are normalized to a single space char, and inter-sentence whitespace is omitted). Preserve whitespace has no effect if either newline_boundaries or html_boundaries is specified.
 * `abbreviations`: list of abbreviations to override the original ones for use with other languages. Don't put dots in abbreviations.
 
 

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -15,6 +15,11 @@ exports.sentences = function(text, user_options) {
     if (!text || typeof text !== "string" || !text.length) {
         return [];
     }
+    
+    if (!/\S/.test(text)) {
+      // whitespace-only string has no sentences
+      return [];
+    }
 
     var options = {
         "newline_boundaries"  : false,
@@ -22,6 +27,7 @@ exports.sentences = function(text, user_options) {
         "html_boundaries_tags": ["p","div","ul","ol"],
         "sanitize"            : false,
         "allowed_tags"        : false,
+        "preserve_whitespace" : false,
         "abbreviations"       : null
     };
 
@@ -57,8 +63,14 @@ exports.sentences = function(text, user_options) {
     }
 
     // Split the text into words
-    // - see http://blog.tompawlak.org/split-string-into-tokens-javascript
-    var words = text.trim().match(/\S+|\n/g);
+    var words;
+    var tokens;
+    // <br> tags are the odd man out, as whitespace is allowed inside the tag
+    tokens = text.split(/(<br\s*\/?>|\S+|\n+)/);
+    // every other token is a word
+    words = tokens.filter(function (token, ii) {
+      return ii % 2;
+    });
 
     var wordCount = 0;
     var index = 0;
@@ -206,7 +218,19 @@ exports.sentences = function(text, user_options) {
     });
 
     for (var i=0; i < sentences.length; i++) {
-        sentence = sentences[i].join(" ");
+        if (options.preserve_whitespace && !options.newline_boundaries && !options.html_boundaries) {
+          // tokens looks like so: [leading-space token, non-space token, space
+          // token, non-space token, space token... ]. In other words, the first
+          // item is the leading space (or the empty string), and the rest of
+          // the tokens are [non-space, space] token pairs.
+          var tokenCount = sentences[i].length * 2;
+          if (i === 0) {
+            tokenCount += 1;
+          }
+          sentence = tokens.splice(0, tokenCount).join('');
+        } else {
+          sentence = sentences[i].join(" ");
+        }
 
         // Single words, could be "enumeration lists"
         if (sentences[i].length === 1 && sentences[i][0].length < 4 &&

--- a/test/preserve_whitespace.js
+++ b/test/preserve_whitespace.js
@@ -1,0 +1,47 @@
+/*jshint node:true, laxcomma:true */
+/*global describe:true, it:true */
+"use strict";
+
+var assert = require('assert');
+var tokenizer = require('../lib/tokenizer');
+var options = { preserve_whitespace: true };
+
+describe('Preserve whitespace', function () {
+
+    describe('Basic', function () {
+        var entry = " This is\ta  sentence   with  funny whitespace.  And this  is \tanother.\tHere  is   a third. ";
+        var sentences = tokenizer.sentences(entry, options);
+
+        it("should get 3 sentences", function () {
+            assert.equal(sentences.length, 3);
+        });
+        it('funny whitespace is preserved in the sentences', function () {
+            assert.equal(sentences.join(''), entry);
+            assert.equal(sentences[0], " This is\ta  sentence   with  funny whitespace.  ");
+            assert.equal(sentences[1], "And this  is \tanother.\t");
+            assert.equal(sentences[2], "Here  is   a third. ");
+        });
+    });
+
+    describe('no effect if incompatible option is specified', function () {
+        var entry = " This is\ta  sentence   with  funny whitespace. ";
+        var sentences = tokenizer.sentences(entry, Object.assign({ newline_boundaries: true }, options));
+
+        it("should get 1 sentences", function () {
+            assert.equal(sentences.length, 1);
+        });
+        it('funny whitespace is not preserved when newline_boundaries is specified', function () {
+            assert.equal(sentences[0], "This is a sentence with funny whitespace.");
+        });
+
+        sentences = tokenizer.sentences(entry, Object.assign({ html_boundaries: true }, options));
+
+        it("should get 1 sentences", function () {
+            assert.equal(sentences.length, 1);
+        });
+        it('funny whitespace is not preserved when html_boundaries is specified', function () {
+            assert.equal(sentences[0], "This is a sentence with funny whitespace.");
+        });
+    });
+
+});


### PR DESCRIPTION
So that you can always get the original text by joining the sentences together.

I spent some time trying to harmonize the `preserve_whitespace` option with `html_boundaries` and `newline_boundaries`. I got that working in another branch, although I ended up doing a fair bit of refactoring around the `newline_placeholder`. But I wasn't confident that the refactor wasn't going to change behavior around the edges with `html_boundaries` and `newline_boundaries`, so I've set that branch aside for the moment.