### PR TITLE
Don't use `this` to refer to variables on export

### DIFF
--- a/lib/Match.js
+++ b/lib/Match.js
@@ -70,13 +70,13 @@ exports.setAbbreviations = function(abbr) {
     }
 }
 
-exports.isCapitalized = function(str) {
-    return /^[A-Z][a-z].*/.test(str) || this.isNumber(str);
+var isCapitalized = exports.isCapitalized = function(str) {
+    return /^[A-Z][a-z].*/.test(str) || isNumber(str);
 }
 
 // Start with opening quotes or capitalized letter
 exports.isSentenceStarter = function(str) {
-    return this.isCapitalized(str) || /``|"|'/.test(str.substring(0,2));
+    return isCapitalized(str) || /``|"|'/.test(str.substring(0,2));
 }
 
 exports.isCommonAbbreviation = function(str) {
@@ -107,7 +107,7 @@ exports.isCustomAbbreviation = function(str) {
         return true;
     }
 
-    return this.isCapitalized(str);
+    return isCapitalized(str);
 }
 
 // Uses current word count in sentence and next few words to check if it is
@@ -116,7 +116,7 @@ exports.isCustomAbbreviation = function(str) {
 // ~ TODO Perhaps also consider prev. word?
 exports.isNameAbbreviation = function(wordCount, words) {
     if (words.length > 0) {
-        if (wordCount < 5 && words[0].length < 6 && this.isCapitalized(words[0])) {
+        if (wordCount < 5 && words[0].length < 6 && isCapitalized(words[0])) {
             return true;
         }
 
@@ -130,7 +130,7 @@ exports.isNameAbbreviation = function(wordCount, words) {
     return false;
 }
 
-exports.isNumber = function(str, dotPos) {
+var isNumber = exports.isNumber = function(str, dotPos) {
     if (dotPos) {
         str = str.slice(dotPos-1, dotPos+2);
     }


### PR DESCRIPTION
The common-shakeify plugin is optimizing `exports.isCapitalized` out of the
bundle becuase it's only ever used internally and refered to via `this`.

This is fixed pending browserify/common-shakeify#14, but this also solves
the problem quicker :)